### PR TITLE
feat(ui): 「墨と朱」和風モダンデザインに全面改修

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,6 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
-  plugins: {
-    tailwindcss: {},
-  },
+  plugins: {},
 };
 
 export default config;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,24 @@
+/* 墨と朱 - 和風モダンカラーパレット */
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
+
+  /* 和風カラーパレット */
+  --sumi-black: #1a1a1a;       /* 墨色（メインテキスト）*/
+  --sumi-dark: #2d2d2d;        /* 濃い墨色 */
+  --shu-red: #c41e3a;          /* 朱色（アクセント、ボタン）*/
+  --shu-red-dark: #a01830;     /* 濃い朱色 */
+  --shu-red-light: #e8425a;    /* 明るい朱色 */
+  --kin-gold: #c9a227;         /* 金色（強調、ホバー）*/
+  --kin-gold-light: #d4b84a;   /* 明るい金色 */
+  --washi-cream: #f5f0e6;      /* 和紙色（背景）*/
+  --washi-light: #faf8f3;      /* 明るい和紙色 */
+  --hai-gray: #6b6b6b;         /* 灰色（サブテキスト）*/
+  --hai-light: #9a9a9a;        /* 明るい灰色 */
+
+  /* フォント */
+  --font-serif: 'Noto Serif JP', serif;
+  --font-sans: 'Noto Sans JP', sans-serif;
   --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
@@ -16,4 +34,164 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
+  font-family: var(--font-sans);
+  color: var(--sumi-black);
+}
+
+/* 和紙テクスチャ背景 */
+body {
+  background-color: var(--washi-cream);
+  background-image:
+    /* 微細なノイズテクスチャ */
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.04'/%3E%3C/svg%3E"),
+    /* 和紙の繊維感 */
+    linear-gradient(
+      135deg,
+      transparent 0%,
+      rgba(201, 162, 39, 0.02) 25%,
+      transparent 50%,
+      rgba(196, 30, 58, 0.01) 75%,
+      transparent 100%
+    );
+  background-attachment: fixed;
+}
+
+/* 見出し用明朝体 */
+h1, h2, h3 {
+  font-family: var(--font-serif);
+  font-weight: 700;
+}
+
+/* 朱印風装飾 */
+.shu-stamp {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background-color: var(--shu-red);
+  color: var(--washi-cream);
+  border-radius: 4px;
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-weight: 700;
+  transform: rotate(-3deg);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 255, 255, 0.2),
+    2px 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+/* 和紙カード */
+.washi-card {
+  background: linear-gradient(
+    145deg,
+    var(--washi-light) 0%,
+    var(--washi-cream) 50%,
+    rgba(201, 162, 39, 0.05) 100%
+  );
+  border: 1px solid rgba(26, 26, 26, 0.1);
+  border-radius: 8px;
+  box-shadow:
+    0 4px 6px rgba(26, 26, 26, 0.08),
+    0 1px 3px rgba(26, 26, 26, 0.1);
+}
+
+/* ボタン共通スタイル */
+.btn-shu {
+  background: linear-gradient(
+    180deg,
+    var(--shu-red-light) 0%,
+    var(--shu-red) 50%,
+    var(--shu-red-dark) 100%
+  );
+  color: white;
+  font-family: var(--font-serif);
+  font-weight: 700;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 2rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow:
+    0 4px 12px rgba(196, 30, 58, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.btn-shu:hover {
+  background: linear-gradient(
+    180deg,
+    var(--kin-gold-light) 0%,
+    var(--kin-gold) 50%,
+    #b8941f 100%
+  );
+  box-shadow:
+    0 6px 16px rgba(201, 162, 39, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  transform: translateY(-2px);
+}
+
+.btn-shu:active {
+  transform: translateY(0);
+}
+
+/* フェードインアニメーション */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes brushStroke {
+  0% {
+    clip-path: inset(0 100% 0 0);
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+@keyframes gentleFloat {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+.animate-fade-in {
+  animation: fadeInUp 0.6s ease-out forwards;
+}
+
+.animate-brush {
+  animation: brushStroke 0.8s ease-out forwards;
+}
+
+/* 選択時のハイライト */
+::selection {
+  background-color: var(--shu-red);
+  color: white;
+}
+
+/* スクロールバー */
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--washi-cream);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--hai-gray);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--sumi-dark);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { ChakraProvider } from '@chakra-ui/react';
 import { Analytics } from "@vercel/analytics/react"
+import './globals.css';
 
 export const metadata: Metadata = {
   title: '札分けアプリ 競技かるた',
@@ -19,6 +20,12 @@ export default function RootLayout({
       <head>
         <link rel="canonical" href="https://fudawake.vercel.app/" />
         <meta name="google-site-verification" content="3w5Pf4GL9rAPnUVPfN8cgTKnSNAmIHcd4G0JYEeJiyk" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
       </head>
       <body>
         <ChakraProvider>{children}</ChakraProvider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,36 +11,113 @@ import { FaTwitter, FaGithub } from 'react-icons/fa';
 
 const currentYear = new Date().getFullYear();
 
+// 和風カラー定数
+const colors = {
+  sumiBlack: '#1a1a1a',
+  shuRed: '#c41e3a',
+  kinGold: '#c9a227',
+  washiCream: '#f5f0e6',
+  washiLight: '#faf8f3',
+  haiGray: '#6b6b6b',
+};
+
 export default function Footer() {
   return (
-    <Box as="footer" bg="gray.100" py={{ base: 2, md: 4 }} mt={8}>
-      <Container maxW="container.xl">
+    <Box
+      as="footer"
+      bg={colors.sumiBlack}
+      py={{ base: 4, md: 6 }}
+      mt="auto"
+      position="relative"
+      overflow="hidden"
+    >
+      {/* 装飾ライン */}
+      <Box
+        position="absolute"
+        top="0"
+        left="0"
+        right="0"
+        h="2px"
+        bgGradient={`linear(to-r, transparent, ${colors.kinGold}, ${colors.shuRed}, ${colors.kinGold}, transparent)`}
+      />
+
+      <Container maxW="container.md">
         <Flex
-          direction={{ base: 'row', md: 'row' }}
+          direction={{ base: 'column', md: 'row' }}
           justify="space-between"
           align="center"
-          fontSize={{ base: 'xs', md: 'sm' }}
+          gap={{ base: 3, md: 0 }}
         >
-          <Text>{`© ${currentYear} 札分け`}</Text>
-          <HStack spacing={{ base: 2, md: 4 }}>
-            <Link href="https://twitter.com/0kdynnkw" isExternal>
+          <HStack spacing={2}>
+            {/* 朱印風ロゴ */}
+            <Box
+              display="inline-flex"
+              alignItems="center"
+              justifyContent="center"
+              w="1.5rem"
+              h="1.5rem"
+              bg={colors.shuRed}
+              color={colors.washiCream}
+              borderRadius="3px"
+              fontFamily="'Noto Serif JP', serif"
+              fontSize="0.625rem"
+              fontWeight="700"
+              transform="rotate(-3deg)"
+              boxShadow="inset 0 0 0 1px rgba(255, 255, 255, 0.2)"
+            >
+              札
+            </Box>
+            <Text
+              fontSize={{ base: 'xs', md: 'sm' }}
+              color={colors.washiCream}
+              fontFamily="'Noto Sans JP', sans-serif"
+              opacity={0.8}
+            >
+              {`© ${currentYear} 札分け`}
+            </Text>
+          </HStack>
+
+          <HStack spacing={{ base: 1, md: 2 }}>
+            <Link
+              href="https://twitter.com/0kdynnkw"
+              isExternal
+              _hover={{ textDecoration: 'none' }}
+            >
               <IconButton
                 aria-label="Twitter"
                 icon={<FaTwitter />}
                 size="sm"
                 fontSize={{ base: '14px', md: '16px' }}
-                colorScheme="twitter"
-                variant="ghost"
+                bg="transparent"
+                color={colors.washiCream}
+                opacity={0.7}
+                _hover={{
+                  opacity: 1,
+                  color: '#1DA1F2',
+                  transform: 'translateY(-2px)',
+                }}
+                transition="all 0.2s ease"
               />
             </Link>
-            <Link href="https://github.com/ko1ynnky" isExternal>
+            <Link
+              href="https://github.com/ko1ynnky"
+              isExternal
+              _hover={{ textDecoration: 'none' }}
+            >
               <IconButton
                 aria-label="GitHub"
                 icon={<FaGithub />}
                 size="sm"
                 fontSize={{ base: '14px', md: '16px' }}
-                colorScheme="gray"
-                variant="ghost"
+                bg="transparent"
+                color={colors.washiCream}
+                opacity={0.7}
+                _hover={{
+                  opacity: 1,
+                  color: colors.washiCream,
+                  transform: 'translateY(-2px)',
+                }}
+                transition="all 0.2s ease"
               />
             </Link>
           </HStack>

--- a/src/components/KarutaApp.tsx
+++ b/src/components/KarutaApp.tsx
@@ -10,8 +10,11 @@ import {
   Text,
   HStack,
   IconButton,
+  Container,
+  Flex,
 } from '@chakra-ui/react';
 import { DeleteIcon } from '@chakra-ui/icons';
+import { motion, AnimatePresence } from 'framer-motion';
 import {
   RulePosition,
   SelectedPositions,
@@ -29,7 +32,23 @@ import {
 } from '../utils/ruleGenerators';
 import Footer from './Footer';
 
+const MotionBox = motion(Box);
+const MotionVStack = motion(VStack);
+
 const STORAGE_KEY = 'karutaAppHistory';
+
+// 和風カラー定数
+const colors = {
+  sumiBlack: '#1a1a1a',
+  shuRed: '#c41e3a',
+  shuRedDark: '#a01830',
+  shuRedLight: '#e8425a',
+  kinGold: '#c9a227',
+  kinGoldLight: '#d4b84a',
+  washiCream: '#f5f0e6',
+  washiLight: '#faf8f3',
+  haiGray: '#6b6b6b',
+};
 
 export default function KarutaApp() {
   const [ruleDescription, setRuleDescription] = useState<string[]>([]);
@@ -57,6 +76,7 @@ export default function KarutaApp() {
     }
     return [];
   });
+  const [isGenerating, setIsGenerating] = useState(false);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -70,13 +90,11 @@ export default function KarutaApp() {
         ...prev,
         [key]: !prev[key],
       };
-      console.log('Updated selectedPositions:', newState);
       return newState;
     });
   };
 
   const generateRandomRule = useCallback(() => {
-    console.log('Current selectedPositions:', selectedPositions);
     const availablePositions = RULE_POSITIONS.filter(
       (position) => selectedPositions[position.key]
     );
@@ -85,6 +103,8 @@ export default function KarutaApp() {
       setRuleDescription(['ルールを選択してください']);
       return;
     }
+
+    setIsGenerating(true);
 
     const selectedPosition =
       availablePositions[Math.floor(Math.random() * availablePositions.length)];
@@ -112,99 +132,381 @@ export default function KarutaApp() {
         newRuleDescription = ['未知のルールタイプです'];
     }
 
-    setRuleDescription(newRuleDescription);
+    setTimeout(() => {
+      setRuleDescription(newRuleDescription);
+      setIsGenerating(false);
 
-    // 履歴に追加
-    setHistory((prevHistory) => {
-      const newHistory = [
-        { id: Date.now().toString(), description: newRuleDescription },
-        ...prevHistory,
-      ];
-      return newHistory.slice(0, 10); // 最大10件を保持
-    });
+      setHistory((prevHistory) => {
+        const newHistory = [
+          { id: Date.now().toString(), description: newRuleDescription },
+          ...prevHistory,
+        ];
+        return newHistory.slice(0, 10);
+      });
+    }, 300);
   }, [selectedPositions]);
 
   const deleteHistoryItem = (id: string) => {
     setHistory((prevHistory) => prevHistory.filter((item) => item.id !== id));
   };
 
-  useEffect(() => {
-    console.log('selectedPositions changed:', selectedPositions);
-  }, [selectedPositions]);
-
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh">
-      <Box as="main" p={4} flex={1}>
-        <VStack spacing={4} align="stretch">
-          <Heading as="h1" size="xl">
-            札分け
+      <Container maxW="container.md" py={{ base: 6, md: 10 }} flex={1}>
+        {/* ヘッダー */}
+        <MotionBox
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          textAlign="center"
+          mb={{ base: 6, md: 10 }}
+        >
+          <Flex justify="center" align="center" gap={3}>
+            <Box
+              display="inline-flex"
+              alignItems="center"
+              justifyContent="center"
+              w="2.5rem"
+              h="2.5rem"
+              bg={colors.shuRed}
+              color={colors.washiCream}
+              borderRadius="6px"
+              fontFamily="'Noto Serif JP', serif"
+              fontSize="1rem"
+              fontWeight="700"
+              transform="rotate(-3deg)"
+              boxShadow="inset 0 0 0 2px rgba(255, 255, 255, 0.2), 2px 2px 4px rgba(0, 0, 0, 0.15)"
+            >
+              札
+            </Box>
+            <Heading
+              as="h1"
+              fontSize={{ base: '2.5rem', md: '3.5rem' }}
+              fontFamily="'Noto Serif JP', serif"
+              fontWeight="700"
+              color={colors.sumiBlack}
+              letterSpacing="0.1em"
+            >
+              札分け
+            </Heading>
+          </Flex>
+          <Text
+            mt={2}
+            fontSize="sm"
+            color={colors.haiGray}
+            fontFamily="'Noto Sans JP', sans-serif"
+          >
+            競技かるた練習用ルール生成
+          </Text>
+        </MotionBox>
+
+        {/* ルール選択カード */}
+        <MotionBox
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          bg="linear-gradient(145deg, #faf8f3 0%, #f5f0e6 50%, rgba(201, 162, 39, 0.05) 100%)"
+          border="1px solid rgba(26, 26, 26, 0.1)"
+          borderRadius="12px"
+          boxShadow="0 4px 6px rgba(26, 26, 26, 0.08), 0 1px 3px rgba(26, 26, 26, 0.1)"
+          p={{ base: 5, md: 8 }}
+          mb={6}
+        >
+          <Heading
+            as="h2"
+            size="md"
+            mb={5}
+            fontFamily="'Noto Serif JP', serif"
+            color={colors.sumiBlack}
+            display="flex"
+            alignItems="center"
+            gap={2}
+          >
+            <Box
+              as="span"
+              w="4px"
+              h="1.2em"
+              bg={colors.shuRed}
+              borderRadius="2px"
+            />
+            使用するルール
           </Heading>
 
-          <VStack spacing={2} align="stretch">
-            <Heading as="h2" size="md" mb={2}>
-              使用するルール
-            </Heading>
-
-            {RULE_POSITIONS.map((position) => (
-              <Checkbox
+          <VStack spacing={3} align="stretch" mb={6}>
+            {RULE_POSITIONS.map((position, index) => (
+              <MotionBox
                 key={position.key}
-                isChecked={selectedPositions[position.key]}
-                onChange={() => handlePositionChange(position.key)}
-                colorScheme="green"
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.4, delay: 0.1 * index }}
               >
-                {position.label}
-              </Checkbox>
+                <Checkbox
+                  isChecked={selectedPositions[position.key]}
+                  onChange={() => handlePositionChange(position.key)}
+                  colorScheme="red"
+                  size="lg"
+                  sx={{
+                    '.chakra-checkbox__control': {
+                      borderColor: colors.haiGray,
+                      borderWidth: '2px',
+                      borderRadius: '4px',
+                      _checked: {
+                        bg: colors.shuRed,
+                        borderColor: colors.shuRed,
+                      },
+                    },
+                    '.chakra-checkbox__label': {
+                      fontFamily: "'Noto Sans JP', sans-serif",
+                      fontSize: { base: 'sm', md: 'md' },
+                      color: colors.sumiBlack,
+                    },
+                  }}
+                >
+                  {position.label}
+                </Checkbox>
+              </MotionBox>
             ))}
+          </VStack>
 
-            <Button
-              onClick={generateRandomRule}
-              colorScheme="green"
-              mt={4}
-              isDisabled={Object.values(selectedPositions).every((v) => !v)}
+          <Button
+            onClick={generateRandomRule}
+            isDisabled={Object.values(selectedPositions).every((v) => !v)}
+            isLoading={isGenerating}
+            loadingText="生成中..."
+            w="100%"
+            h="56px"
+            bg={`linear-gradient(180deg, ${colors.shuRedLight} 0%, ${colors.shuRed} 50%, ${colors.shuRedDark} 100%)`}
+            color="white"
+            fontFamily="'Noto Serif JP', serif"
+            fontWeight="700"
+            fontSize={{ base: 'md', md: 'lg' }}
+            letterSpacing="0.1em"
+            borderRadius="8px"
+            boxShadow="0 4px 12px rgba(196, 30, 58, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.2)"
+            _hover={{
+              bg: `linear-gradient(180deg, ${colors.kinGoldLight} 0%, ${colors.kinGold} 50%, #b8941f 100%)`,
+              boxShadow: '0 6px 16px rgba(201, 162, 39, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.3)',
+              transform: 'translateY(-2px)',
+            }}
+            _active={{
+              transform: 'translateY(0)',
+            }}
+            _disabled={{
+              bg: colors.haiGray,
+              opacity: 0.6,
+              cursor: 'not-allowed',
+              _hover: {
+                transform: 'none',
+              },
+            }}
+            transition="all 0.3s ease"
+          >
+            札分けを決める！
+          </Button>
+        </MotionBox>
+
+        {/* 結果表示 */}
+        <AnimatePresence mode="wait">
+          {ruleDescription.length > 0 && (
+            <MotionBox
+              key={ruleDescription.join('')}
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: -10 }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
+              bg="linear-gradient(145deg, #faf8f3 0%, #f5f0e6 50%, rgba(201, 162, 39, 0.08) 100%)"
+              border="2px solid"
+              borderColor={colors.shuRed}
+              borderRadius="12px"
+              p={{ base: 5, md: 8 }}
+              mb={6}
+              position="relative"
+              overflow="hidden"
             >
-              札分けを決める！
-            </Button>
-            {ruleDescription.length > 0 && (
-              <VStack align="stretch" mt={2}>
-                <Text fontWeight="bold">現在のルール:</Text>
-                {ruleDescription.map((line, index) => (
-                  <Text key={index}>{line}</Text>
-                ))}
-              </VStack>
+              {/* 装飾的な角 */}
+              <Box
+                position="absolute"
+                top="0"
+                left="0"
+                w="20px"
+                h="20px"
+                borderTop="3px solid"
+                borderLeft="3px solid"
+                borderColor={colors.kinGold}
+                borderRadius="4px 0 0 0"
+              />
+              <Box
+                position="absolute"
+                top="0"
+                right="0"
+                w="20px"
+                h="20px"
+                borderTop="3px solid"
+                borderRight="3px solid"
+                borderColor={colors.kinGold}
+                borderRadius="0 4px 0 0"
+              />
+              <Box
+                position="absolute"
+                bottom="0"
+                left="0"
+                w="20px"
+                h="20px"
+                borderBottom="3px solid"
+                borderLeft="3px solid"
+                borderColor={colors.kinGold}
+                borderRadius="0 0 0 4px"
+              />
+              <Box
+                position="absolute"
+                bottom="0"
+                right="0"
+                w="20px"
+                h="20px"
+                borderBottom="3px solid"
+                borderRight="3px solid"
+                borderColor={colors.kinGold}
+                borderRadius="0 0 4px 0"
+              />
+
+              <Text
+                fontSize="xs"
+                color={colors.shuRed}
+                fontFamily="'Noto Sans JP', sans-serif"
+                fontWeight="700"
+                textTransform="uppercase"
+                letterSpacing="0.15em"
+                mb={2}
+              >
+                現在のルール
+              </Text>
+              {ruleDescription.map((line, index) => (
+                <Text
+                  key={index}
+                  fontSize={{ base: 'xl', md: '2xl' }}
+                  fontFamily="'Noto Serif JP', serif"
+                  fontWeight="700"
+                  color={colors.sumiBlack}
+                  lineHeight="1.6"
+                >
+                  {line}
+                </Text>
+              ))}
+            </MotionBox>
+          )}
+        </AnimatePresence>
+
+        {/* 生成履歴 */}
+        <MotionBox
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+        >
+          <Heading
+            as="h2"
+            size="md"
+            mb={4}
+            fontFamily="'Noto Serif JP', serif"
+            color={colors.sumiBlack}
+            display="flex"
+            alignItems="center"
+            gap={2}
+          >
+            <Box
+              as="span"
+              w="4px"
+              h="1.2em"
+              bg={colors.kinGold}
+              borderRadius="2px"
+            />
+            生成履歴
+          </Heading>
+
+          <VStack spacing={3} align="stretch">
+            <AnimatePresence>
+              {history.map((item, index) => (
+                <MotionBox
+                  key={item.id}
+                  initial={{ opacity: 0, x: -20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 20, height: 0 }}
+                  transition={{ duration: 0.3, delay: index * 0.05 }}
+                  layout
+                >
+                  <HStack
+                    justify="space-between"
+                    align="flex-start"
+                    p={4}
+                    bg={colors.washiLight}
+                    border="1px solid rgba(26, 26, 26, 0.08)"
+                    borderRadius="8px"
+                    _hover={{
+                      boxShadow: '0 2px 8px rgba(26, 26, 26, 0.1)',
+                    }}
+                    transition="box-shadow 0.2s ease"
+                  >
+                    <HStack align="flex-start" spacing={3}>
+                      <Box
+                        display="inline-flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        minW="1.75rem"
+                        h="1.75rem"
+                        bg={colors.shuRed}
+                        color={colors.washiCream}
+                        borderRadius="4px"
+                        fontFamily="'Noto Serif JP', serif"
+                        fontSize="xs"
+                        fontWeight="700"
+                        transform="rotate(-2deg)"
+                        boxShadow="1px 1px 2px rgba(0, 0, 0, 0.1)"
+                      >
+                        {history.length - index}
+                      </Box>
+                      <VStack align="start" spacing={0}>
+                        {item.description.map((line, lineIndex) => (
+                          <Text
+                            key={lineIndex}
+                            fontSize="sm"
+                            fontFamily="'Noto Sans JP', sans-serif"
+                            color={colors.sumiBlack}
+                          >
+                            {line}
+                          </Text>
+                        ))}
+                      </VStack>
+                    </HStack>
+                    <IconButton
+                      aria-label="履歴を削除"
+                      icon={<DeleteIcon />}
+                      onClick={() => deleteHistoryItem(item.id)}
+                      size="sm"
+                      variant="ghost"
+                      color={colors.haiGray}
+                      _hover={{
+                        color: colors.shuRed,
+                        bg: 'rgba(196, 30, 58, 0.1)',
+                      }}
+                    />
+                  </HStack>
+                </MotionBox>
+              ))}
+            </AnimatePresence>
+
+            {history.length === 0 && (
+              <Box
+                textAlign="center"
+                py={8}
+                color={colors.haiGray}
+                fontFamily="'Noto Sans JP', sans-serif"
+                fontSize="sm"
+              >
+                まだ履歴がありません
+              </Box>
             )}
           </VStack>
-
-          <VStack spacing={2} align="stretch">
-            <Heading as="h2" size="md" mb={2}>
-              生成履歴
-            </Heading>
-            {history.map((item, index) => (
-              <HStack
-                key={item.id}
-                justify="space-between"
-                p={2}
-                bg="gray.100"
-                borderRadius="md"
-              >
-                <VStack align="start" spacing={0}>
-                  <Text fontWeight="bold">
-                    ルール {history.length - index}:
-                  </Text>
-                  {item.description.map((line, lineIndex) => (
-                    <Text key={lineIndex}>{line}</Text>
-                  ))}
-                </VStack>
-                <IconButton
-                  aria-label="履歴を削除"
-                  icon={<DeleteIcon />}
-                  onClick={() => deleteHistoryItem(item.id)}
-                  size="sm"
-                />
-              </HStack>
-            ))}
-          </VStack>
-        </VStack>
-      </Box>
+        </MotionBox>
+      </Container>
       <Footer />
     </Box>
   );


### PR DESCRIPTION
## Summary

- 競技かるたアプリにふさわしい「墨と朱」和風モダンデザインを導入
- 日本の伝統美を現代的に解釈したデザインシステムを実装
- framer-motionを活用したアニメーション追加

## 主な変更点

### デザイン
- **カラーパレット**: 墨色・朱色・金色・和紙色の伝統的配色
- **タイポグラフィ**: Noto Serif JP（見出し）/ Noto Sans JP（本文）
- **ヘッダー**: 朱印風「札」マークを追加
- **ボタン**: 朱色グラデーション、ホバーで金色に変化
- **結果表示**: 朱色枠線と金色角装飾で「札」を表現
- **履歴**: 朱印風番号バッジ
- **フッター**: 黒背景に金と朱のグラデーションライン
- **背景**: 和紙テクスチャ風のクリーム色

### 技術的変更
- `globals.css`: CSS変数、背景テクスチャ、共通スタイル追加
- `layout.tsx`: Google Fonts読み込み追加
- `KarutaApp.tsx`: メインUIの全面改修、アニメーション追加
- `Footer.tsx`: 和風デザインに統一
- `postcss.config.mjs`: 未使用のtailwindcss設定を削除

## スクリーンショット

改修前: シンプルなChakra UIデフォルトスタイル
改修後: 和紙・墨・朱を基調とした日本の伝統美を感じるデザイン

## Test plan

- [ ] 開発サーバーで表示確認
- [ ] ルール生成ボタンの動作確認
- [ ] アニメーションの動作確認
- [ ] 履歴の追加・削除動作確認
- [ ] レスポンシブデザインの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)