### PR TITLE
chore: サプライチェーン攻撃対策を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'
       - run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+ignore-scripts=true


### PR DESCRIPTION
## Summary
- `.npmrc` に `min-release-age` と `ignore-scripts` を設定
- GitHub Actions のアクションを v2 → v4 に更新し、SHA pinning に変更

## 対策の根拠
- 悪意あるパッケージの大多数は公開後1週間以内に検出・削除されるため、7日間のクールダウンで防御
- `ignore-scripts` でインストール時の任意コード実行を防止
- SHA pinning でアクションのタグ差し替え攻撃を防止

🤖 Generated with [Claude Code](https://claude.com/claude-code)