### PR TITLE
chore: Dependabotにcooldown期間を設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Summary
- npm更新に7日間のcooldown期間を設定

## 対策の根拠
- 新規公開パッケージの悪意あるバージョンは公開後1週間以内に検出・削除される傾向があるため、7日間のクールダウンで防御
- セキュリティ更新には適用されないため、脆弱性修正は即座にPRが作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)